### PR TITLE
MQTT: Use clean session connection

### DIFF
--- a/src/qt/ve_qitems_mqtt.cpp
+++ b/src/qt/ve_qitems_mqtt.cpp
@@ -587,7 +587,7 @@ void VeQItemMqttProducer::continueConnect()
 	// race condition where we might have two connections active.
 	QMetaObject::invokeMethod(this, [this] {
 		if (mMqttConnection) {
-			mMqttConnection->setCleanSession(false);
+			mMqttConnection->setCleanSession(true);
 			mMqttConnection->connectToHost();
 		} else {
 			// the MQTT connection was deleted out from under us...


### PR DESCRIPTION
We don't re-use old sessions since we regenerate a unique session id upon each connection.

Hence, don't require the broker to keep the old session around after connection is lost, otherwise these can accumulate and cause increased memory and CPU usage.