### PR TITLE
ve_quick_item: send the correct type in SetValue

### DIFF
--- a/inc/veutil/qt/ve_quick_item.hpp
+++ b/inc/veutil/qt/ve_quick_item.hpp
@@ -137,7 +137,7 @@ public:
 	QVariant getSourceValue() { return mItem ? mItem->getValue() : QVariant(); }
 	VeQItem::State getState() { return mItem ? mItem->getState() : VeQItem::Idle; }
 	bool getSeen() { return mItem ? mItem->getSeen() : false; }
-	Q_INVOKABLE int setValue(QVariant const &value) { return mItem ? mItem->setValue(convertFromDisplay(value)) : 0; }
+	Q_INVOKABLE int setValue(QVariant const &value);
 	void setValueProperty(QVariant value);
 	void setSourceValueProperty(QVariant const &value);
 	QString getUnit() const { return mUnit; }

--- a/src/qt/ve_quick_item.cpp
+++ b/src/qt/ve_quick_item.cpp
@@ -101,6 +101,31 @@ QVariant VeQuickItem::getValue(bool force)
 	return convertToDisplay(value);
 }
 
+int VeQuickItem::setValue(const QVariant &value)
+{
+	if (!mItem)
+		return 0;
+
+	QVariant newValue = convertFromDisplay(value);
+
+	// Since javascript isn't typed, it uses "number" for all of numeric ones,
+	// the type of the value might have changed to double / int. So change it
+	// back to the type of the received value. Furthermore this also ensures the
+	// correct type is written back if unit conversion is used.
+	if (newValue.isValid()) {
+		QVariant currentValue = mItem->getLocalValue();
+		QMetaType type = currentValue.metaType();
+		bool ok = type.isValid() ? newValue.convert(type) : true;
+
+		if (!ok) {
+			newValue = convertFromDisplay(value);
+			qWarning() << getUid() << "cannot convert " << newValue << "to" << type;
+		}
+	}
+
+	return mItem->setValue(newValue);
+}
+
 /**
  * Handle changes of the value property.
  *


### PR DESCRIPTION
The javascript engine isn't strictly typed and might convert an int to a double, especially when an operation is performed on it. But it seems even round returns a double in Qt6.

Services aren't supposed to be too picky about accepting values if they can trivially convert it, but since this is since Qt6, there are bugs in there. So this is the "be carefull what you send" part.

When an unit converter is used, this now also sends the same type back as was reiceived instead of a double.

https://github.com/victronenergy/venus-private/issues/558 (cherry picked from commit 60a952abf0f9f06b49cc403200aefe32daaa5d23)