### PR TITLE
MQTT: wait for subscription confirmation before sending keep-alive

### DIFF
--- a/inc/veutil/qt/ve_qitems_mqtt.hpp
+++ b/inc/veutil/qt/ve_qitems_mqtt.hpp
@@ -146,6 +146,8 @@ private Q_SLOTS:
 	void onStateChanged(QMqttClient::ClientState state);
 	void onMessageReceived(const QByteArray &message, const QMqttTopicName &topic);
 	void onSubscriptionMessageReceived(const QMqttMessage &message);
+	void onSubscriptionStateChanged(QMqttSubscription::SubscriptionState state);
+	void doInitialSubscriptionKeepAlive();
 	void doKeepAlive(bool suppressRepublish = false);
 
 private:
@@ -174,6 +176,7 @@ private:
 	QTimer *mKeepAliveTimer;
 	QTimer *mHeartBeatTimer;
 	QTimer *mReadyStateFallbackTimer;
+	QTimer *mSubscriptionStateTimer;
 	QMqttClient *mMqttConnection;
 	QPointer<QMqttSubscription> mMqttSubscription;
 #ifdef MQTT_WEBSOCKETS_ENABLED

--- a/src/qt/ve_qitems_mqtt.cpp
+++ b/src/qt/ve_qitems_mqtt.cpp
@@ -79,6 +79,7 @@ VeQItemMqttProducer::VeQItemMqttProducer(
 	  mKeepAliveTimer(new QTimer(this)),
 	  mHeartBeatTimer(new QTimer(this)),
 	  mReadyStateFallbackTimer(new QTimer(this)),
+	  mSubscriptionStateTimer(new QTimer(this)),
 	  mMqttConnection(nullptr),
 	  mPort(0),
 	  mVrmPortalMode(Unknown),
@@ -186,6 +187,7 @@ bool VeQItemMqttProducer::isValidStateTransition(ConnectionState from, Connectio
 		case Identified:
 			return to == Initializing
 				|| to == Disconnected
+				|| to == Failed
 				|| to == Idle;
 		case Initializing:
 			return to == Ready
@@ -426,9 +428,37 @@ void VeQItemMqttProducer::transitionState()
 					qWarning() << "MQTT: previous subscription was not cleared! FIXME!";
 				}
 				mMqttSubscription = mMqttConnection->subscribe(QStringLiteral("N/%1/#").arg(mPortalId));
+				if (!mMqttSubscription) {
+					qWarning() << "MQTT: unable to subscribe to topics";
+					// it should automatically retry to connect after a minute.
+					enqueueStateTransition({
+						QStringLiteral("Identified"),
+						Identified,
+						Failed,
+						false, // don't set error.
+						QMqttClient::NoError
+					});
+					break;
+				}
+
 				QObject::connect(mMqttSubscription.data(), &QMqttSubscription::messageReceived,
 					this, &VeQItemMqttProducer::onSubscriptionMessageReceived, Qt::UniqueConnection);
-				doKeepAlive(/* suppressRepublish = */ false);
+
+				// subscription will most likely be in SubscriptionPending
+				// state until the broker confirms the subscription.
+				if (mMqttSubscription->state() == QMqttSubscription::Subscribed) {
+					qDebug() << "Identified, MQTT subscription ready";
+					doKeepAlive(/* suppressRepublish = */ false);
+				} else {
+					qDebug() << "Identified, waiting for MQTT subscription";
+					QObject::connect(mMqttSubscription.data(), &QMqttSubscription::stateChanged,
+						this, &VeQItemMqttProducer::onSubscriptionStateChanged, Qt::UniqueConnection);
+					QObject::connect(mSubscriptionStateTimer, &QTimer::timeout,
+						this, &VeQItemMqttProducer::doInitialSubscriptionKeepAlive, Qt::UniqueConnection);
+					mSubscriptionStateTimer->setInterval(3000);
+					mSubscriptionStateTimer->setSingleShot(true);
+					mSubscriptionStateTimer->start();
+				}
 				break;
 			}
 
@@ -613,10 +643,14 @@ void VeQItemMqttProducer::stop()
 	mKeepAliveTimer->stop();
 	mHeartBeatTimer->stop();
 	mReadyStateFallbackTimer->stop();
+	mSubscriptionStateTimer->stop();
+	disconnect(mSubscriptionStateTimer, &QTimer::timeout, this, &VeQItemMqttProducer::doInitialSubscriptionKeepAlive);
 	if (mMqttSubscription.data()) {
 		mMqttSubscription->unsubscribe();
 		QObject::disconnect(mMqttSubscription.data(), &QMqttSubscription::messageReceived,
 			this, &VeQItemMqttProducer::onSubscriptionMessageReceived);
+		QObject::disconnect(mMqttSubscription.data(), &QMqttSubscription::stateChanged,
+			this, &VeQItemMqttProducer::onSubscriptionStateChanged);
 		mMqttSubscription.clear();
 	}
 }
@@ -676,6 +710,23 @@ void VeQItemMqttProducer::onMessageReceived(const QByteArray &message, const QMq
 					<< topicName << " -> " << QString::fromUtf8(message);
 			}
 		}
+	}
+}
+
+void VeQItemMqttProducer::doInitialSubscriptionKeepAlive()
+{
+	mSubscriptionStateTimer->stop();
+	if (mMqttSubscription) {
+		disconnect(mMqttSubscription.data(), &QMqttSubscription::stateChanged, this, &VeQItemMqttProducer::onSubscriptionStateChanged);
+	}
+	doKeepAlive(/* suppressRepublish = */ false);
+}
+
+void VeQItemMqttProducer::onSubscriptionStateChanged(QMqttSubscription::SubscriptionState state)
+{
+	if (state == QMqttSubscription::Subscribed) {
+		qDebug() << "Identified, MQTT subscription acknowledged";
+		doInitialSubscriptionKeepAlive();
 	}
 }
 
@@ -1064,6 +1115,8 @@ void VeQItemMqttProducer::deleteMqttConnection()
 		mMqttSubscription->unsubscribe();
 		QObject::disconnect(mMqttSubscription.data(), &QMqttSubscription::messageReceived,
 			this, &VeQItemMqttProducer::onSubscriptionMessageReceived);
+		QObject::disconnect(mMqttSubscription.data(), &QMqttSubscription::stateChanged,
+			this, &VeQItemMqttProducer::onSubscriptionStateChanged);
 		mMqttSubscription.clear();
 	}
 	if (mMqttConnection) {


### PR DESCRIPTION
The confirmation will be delayed until all servers which need to acknowledge have done so.  This commit ensures we wait for the subscription state to transition from SubscriptionPending to Subscribed (or if a three-second timeout is reached) before sending the keep-alive message.

Contributes to issue 2962 in gui-v2