### PR TITLE
Models: add VeQItemSortTableModel::filterExcludedValue

### DIFF
--- a/inc/veutil/qt/ve_qitem_sort_table_model.hpp
+++ b/inc/veutil/qt/ve_qitem_sort_table_model.hpp
@@ -25,6 +25,7 @@ class VeQItemSortTableModel : public QSortFilterProxyModel, public QDeclarativeP
 	Q_ENUMS(Flags)
 	Q_PROPERTY(Flags filterFlags READ filterFlags WRITE setFilterFlags NOTIFY filterFlagsChanged)
 	Q_PROPERTY(QString filterRegExp READ filterRegExpStr WRITE setFilterRegExp NOTIFY filterRegExpChanged)
+	Q_PROPERTY(QVariant filterExcludedValue READ filterExcludedValue WRITE setFilterExcludedValue NOTIFY filterExcludedValueChanged)
 	Q_PROPERTY(VeQItemTableModel *model READ model WRITE setModel NOTIFY modelChanged)
 	Q_PROPERTY(bool dynamicSortFilter READ dynamicSortFilter WRITE setDynamicSortFilter NOTIFY dynamicSortFilterChanged)
 	Q_PROPERTY(int sortRole READ sortRole WRITE setSortRole NOTIFY sortRoleChanged)
@@ -36,6 +37,7 @@ public:
 		None = 0,
 		FilterInvalid = 1,
 		FilterOffline = 2,
+		FilterExcludesValue = 4,
 	};
 
 	Q_DECLARE_FLAGS(Flags, Flag)
@@ -74,6 +76,9 @@ public:
 	Flags filterFlags() { return mFlags; }
 	void setFilterFlags(Flags flags);
 
+	QVariant filterExcludedValue() const { return mFilterExcludedValue; }
+	void setFilterExcludedValue(const QVariant &v);
+
 	Q_INVOKABLE int sortColumn() {
 		return QSortFilterProxyModel::sortColumn();
 	}
@@ -100,6 +105,7 @@ public:
 signals:
 	void filterRegExpChanged();
 	void filterFlagsChanged();
+	void filterExcludedValueChanged();
 	void modelChanged();
 	void dynamicSortFilterChanged();
 	void sortRoleChanged();
@@ -110,6 +116,7 @@ private:
 	bool mCompleted;
 	VeQItemTableModel *mTableModel;
 	Flags mFlags;
+	QVariant mFilterExcludedValue;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(VeQItemSortTableModel::Flags)

--- a/src/qt/ve_qitem_sort_table_model.cpp
+++ b/src/qt/ve_qitem_sort_table_model.cpp
@@ -82,6 +82,14 @@ void VeQItemSortTableModel::setFilterFlags(VeQItemSortTableModel::Flags flags) {
 	invalidateFilter();
 }
 
+void VeQItemSortTableModel::setFilterExcludedValue(const QVariant &excludedValue) {
+	if (mFilterExcludedValue == excludedValue)
+		return;
+	mFilterExcludedValue = excludedValue;
+	emit filterExcludedValueChanged();
+	invalidateFilter();
+}
+
 bool VeQItemSortTableModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
 	if (!QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent))
@@ -91,6 +99,12 @@ bool VeQItemSortTableModel::filterAcceptsRow(int source_row, const QModelIndex &
 		return true;
 
 	QModelIndex index = sourceModel()->index(source_row, 0, source_parent);
+
+	if (mFlags.testFlag(FilterExcludesValue)) {
+		QVariant value = sourceModel()->data(index, VeQItemTableModel::ValueRole);
+		if (value == mFilterExcludedValue)
+			return false;
+	}
 
 	if (mFlags.testFlag(FilterInvalid)) {
 		QVariant value = sourceModel()->data(index, VeQItemTableModel::ValueRole);


### PR DESCRIPTION
If the model filter is set to FilterExcludesValue, it will exclude rows where the value matches the filterExcludedValue.

https://github.com/victronenergy/gui-v2/issues/2885